### PR TITLE
Removes _do_ from init example task

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -31,7 +31,7 @@ function example_function()
   print("Hello world")
 end
 
-task example do -- This is a task description
+task example -- This is a task description
   example_function()
 
   exec("ls -la")


### PR DESCRIPTION
fc73277a deprecated the need for the `do` statement in task declarations. The default manifest from `motive init` still contained `do`, which causes every command to break.

This PR removes the deprecated statement from the default manifest.