### PR TITLE
Use docker to build Linux builds

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+docker run -i -v ${PWD}:/host rust:1.58 sh << COMMANDS                                     
+cd /host; cargo build --release
+COMMANDS
+


### PR DESCRIPTION
This PR includes a script (just the script) that can be explicitly called when you, on say, an x86 or arm based mac, want to produce a linux build for the build system.

Requires: Docker installed, and your user has permission to use it (otherwise you can run it with sudo, but you will have permission issues if you go to build motive natively after the fact).

Uses a volume to build, and the release binary will be in the usual spot `target/release/motive`